### PR TITLE
Fixing a number of issues related to uncached urls, adding support for getting results based on URL alone

### DIFF
--- a/frontend/app/src/containers/buildResultPage.js
+++ b/frontend/app/src/containers/buildResultPage.js
@@ -7,12 +7,20 @@ export default function BuildResultPage({ resultObj }) {
         <div className="d-flex h-95vh  w-100 px-5 flex-column">
           <div className="flex-row pb-2">
             <h1>{title}</h1>
-            <div className="d-flex justify-content-center ws-pre-wrap">
-              <div>Original Document: </div>{" "}
-              <a href={`${orig_url}#page=${page}`} target="_blank" rel="noreferrer">
-                Click Here
-              </a>
-            </div>
+            {orig_url.length > 0 ? (
+              <div className="d-flex justify-content-center ws-pre-wrap">
+                <div>Original Document: </div>{" "}
+                <a
+                  href={`${orig_url}#page=${page}`}
+                  target="_blank"
+                  rel="noreferrer"
+                >
+                  Click Here
+                </a>
+              </div>
+            ) : (
+              <></>
+            )}
           </div>
           <div className="row w-100 h-100">
             <div className="col d-flex justify-content-center border">

--- a/frontend/app/src/hooks/getBuildPdfByPath.js
+++ b/frontend/app/src/hooks/getBuildPdfByPath.js
@@ -1,0 +1,43 @@
+import React, { useState, useEffect, useRef } from "react";
+import CheckUrlStatus from "../utils/checkUrlStatus";
+import BuildResultPage from "../containers/buildResultPage";
+import LoadingRing from "../containers/loadingRing";
+
+export default function BuildPdfByPath({ formattedPdfRef, possibleUrl }) {
+  const [resultObj, setResultObj] = useState({});
+  let awaitingFetch = useRef(true);
+  let iframeStatus = useRef(false);
+
+  useEffect(() => {
+    CheckUrlStatus(possibleUrl).then((res) => {
+      setResultObj({
+        orig_url: "",
+        title: formattedPdfRef.title,
+        url: `https://sad.nyc3.digitaloceanspaces.com/${formattedPdfRef.path}.pdf`,
+        page: formattedPdfRef.page,
+        id: "NaN",
+      });
+      iframeStatus.current = res;
+      console.log('***res',res)
+      awaitingFetch.current = false;
+    });
+  }, [formattedPdfRef,possibleUrl]);
+
+  return (
+    <div>
+      {awaitingFetch.current ? (
+        <div className="App-bg">
+          <div className="m-2">Loading Results For {formattedPdfRef.path}.pdf</div>
+          <LoadingRing />
+        </div>
+      ) : iframeStatus.current === 0 ? (
+        <BuildResultPage resultObj={resultObj} />
+      ) : (
+        <div className="App-bg">
+          We couldn't find any results matching {formattedPdfRef.path}.pdf
+          <div>Try searching on <a href='/'> our homepage </a> instead!</div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/frontend/app/src/hooks/getDataById.js
+++ b/frontend/app/src/hooks/getDataById.js
@@ -27,13 +27,13 @@ export default function GetDataById({ paramId }) {
           fetchSuccess.current = true;
         } else {
           awaitingFetch.current = false;
-          setResultObj({})
+          setResultObj({});
         }
       })
       .catch(() => {
         console.log(`Fetching for id "${paramId}" failed`);
         awaitingFetch.current = false;
-        setResultObj({})
+        setResultObj({});
       });
   }, [paramId]);
 
@@ -41,13 +41,18 @@ export default function GetDataById({ paramId }) {
     <div>
       {awaitingFetch.current ? (
         <div className="App-bg">
-            <div className="m-2">Loading Results</div>
-            <LoadingRing/>
+          <div className="m-2">Loading Results For ID '{paramId}'</div>
+          <LoadingRing />
         </div>
       ) : fetchSuccess.current ? (
         <BuildResultPage resultObj={resultObj} />
       ) : (
-        <div className="App-bg">We couldn't find any results matching id: '{paramId}'</div>
+        <>
+          <div className="App-bg">
+            <div>We couldn't find any results matching ID: '{paramId}'</div>
+            <div>Try <a href={window.location.pathname}> this page </a> instead!</div>
+          </div>
+        </>
       )}
     </div>
   );

--- a/frontend/app/src/pages/resultPage.js
+++ b/frontend/app/src/pages/resultPage.js
@@ -1,17 +1,32 @@
-import { useLocation } from "react-router-dom";
+import { useLocation, useParams } from "react-router-dom";
 import getUrlParam from "../utils/getUrlParam";
 import BuildResultPage from "../containers/buildResultPage";
 import GetDataById from "../hooks/getDataById";
+import BuildPdfByPath from "../hooks/getBuildPdfByPath";
+import CheckUrlStatus from "../utils/checkUrlStatus";
+import FormatPdfRef from "../utils/formatPdfRef";
+import LoadingRing from "../containers/loadingRing";
 
 export default function ResultPage() {
   const location = useLocation();
   console.log("location state:", location.state);
+  const { pdfRef } = useParams();
+  const formattedPdfRef = FormatPdfRef(pdfRef);
+  const possibleUrl = `https://sad.nyc3.digitaloceanspaces.com/${formattedPdfRef.path}.pdf`;
+
+  console.log("formattedPdfRef", formattedPdfRef);
+
   // do we have data being passed from the previous page?
   if (location.state === null) {
     const paramId = getUrlParam("id");
     // do we have a 'id' url param?
     if (paramId) {
-      return <GetDataById paramId={paramId}/>
+      return <GetDataById paramId={paramId} />;
+    } else if (formattedPdfRef) {
+      // Try building result from just page URL path
+      return (
+        <BuildPdfByPath formattedPdfRef={formattedPdfRef} possibleUrl={possibleUrl} />
+      )
     } else {
       window.location.replace("/404");
       return null;

--- a/frontend/app/src/utils/checkUrlStatus.js
+++ b/frontend/app/src/utils/checkUrlStatus.js
@@ -1,0 +1,13 @@
+export default function CheckUrlStatus(url) {
+  return new Promise((resolve) => {
+    try {
+      fetch(url, {mode: 'no-cors'}).then((result) => {
+        console.log('result',result)
+        resolve(result.status);
+      })
+    } catch (error) {
+      console.log(`Fetch for ${url} failed`);
+      resolve(false)
+    }
+  });
+}

--- a/frontend/app/src/utils/fetchData.js
+++ b/frontend/app/src/utils/fetchData.js
@@ -3,11 +3,17 @@ export default function fetchData(fetchUrl) {
     try {
       fetch(fetchUrl)
         .then((res) => {
-          res.json().then((data) => {
-            // Setting a data from api
-            console.log("fetchData.js", data, Date.now());
-            resolve(data);
-          });
+          try{
+            res.json().then((data) => {
+              // Setting a data from api
+              console.log("fetchData.js", data, Date.now());
+              resolve(data);
+            });
+          } catch (error) {
+            console.log("JSON Error");
+            console.log(error);
+            resolve({ myData: {} });
+          }
         })
         .catch((error) => {
           console.log("fetch failed");

--- a/frontend/app/src/utils/formatPdfRef.js
+++ b/frontend/app/src/utils/formatPdfRef.js
@@ -1,0 +1,17 @@
+export default function FormatPdfRef(pdfRef) {
+  //pdfRef looks like '1940-03-42' or '1940-23'
+  let year = false;
+  let part = false;
+  let page = false;
+  const nums = pdfRef.split("-");
+  console.log('nums', nums)
+  year = nums[0];
+  if (nums.length === 2) {
+    page = nums[1];
+    return {path: year, page: page, title: `${year} Census, Page ${page}`};
+  } else if (nums.length === 3) {
+    part = nums[1];
+    page = nums[2];
+    return {path: `${year}-${part}`, page: page, title: `${year} Census, Part ${part}, Page ${page}`};
+  } else return false;
+}


### PR DESCRIPTION
Adding support for url paths that look like: `/result/1940-03-51`

Before we could only generate results pages using data from the API, now we have logic to add the PDF if the API data is not available. This also has more graceful error handling when an url param id is not found